### PR TITLE
Add saveTransaction

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -159,6 +159,16 @@ class Connection extends EventEmitter {
 		});
 		request.execute(this);
 	}
+	
+	saveTransaction(callback, name) {
+		name = name || '';
+		let request = new Request(`SAVE TRANSACTION "${ name }";`, (err) => {
+			if (typeof callback === 'function') {
+				callback(err);
+			}
+		});
+		request.execute(this);
+	}
 
 	execSql(request) {
 		request.execute(this);


### PR DESCRIPTION
Using  sequelize@4.10.0 I get the following error:

```js
TypeError: connection.saveTransaction is not a function    
at Promise C:\\Users\\...\\node_modules\\sequelize\\lib\\dialects\\mssql\\query.js:88:20)
```

It is here that it fails: https://github.com/sequelize/sequelize/blob/3fedaa431667cabd51b524409a32415b830b0398/lib/dialects/mssql/query.js#L88

Added in this PR
https://github.com/sequelize/sequelize/pull/6972

The quick fix in this PR seemingly makes it work. But this is a bit outside my expertise. But would be nice if support for this was added.

Inspiration taken from here https://github.com/tediousjs/tedious/blob/7727b5aa06e8ee2befed565b73d6a7d0a5fb9b31/src/connection.js#L1178